### PR TITLE
[RTC-237] Refactor for Jellyfish client

### DIFF
--- a/MembraneRTC/Sources/MembraneRTC/EventTransport/EventTransport.swift
+++ b/MembraneRTC/Sources/MembraneRTC/EventTransport/EventTransport.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Promises
 
-public enum EventTransportError: Error {
+public enum PhoenixTransportError: Error {
     /// Thrown when user is not authorized to join the session
     case unauthorized
 
@@ -12,7 +12,7 @@ public enum EventTransportError: Error {
     case unexpected(reason: String)
 }
 
-extension EventTransportError: CustomStringConvertible {
+extension PhoenixTransportError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .unauthorized:
@@ -25,19 +25,8 @@ extension EventTransportError: CustomStringConvertible {
     }
 }
 
-/// Protocol defining a behaviour of an events' transport used for exchaning messages
-/// between client and the server.
-///
-///  An implementation of such transport should take an `EventTransportDelegate` as its argument
-///  and pass received and parsed messages directly to the delegate.
-public protocol EventTransport {
-    func connect(delegate: EventTransportDelegate) -> Promise<Void>
-    func disconnect()
-    func send(event: SendableEvent)
-}
-
-/// Protocol for a delegate listening for messages received by the `EventTransport`
-public protocol EventTransportDelegate: AnyObject {
-    func didReceive(event: ReceivableEvent)
-    func didReceive(error: EventTransportError)
+/// Protocol for a delegate listening for messages received by the `PhoenixTransport`
+public protocol PhoenixTransportDelegate: AnyObject {
+    func didReceive(event: SerializedMediaEvent)
+    func didReceive(error: PhoenixTransportError)
 }

--- a/MembraneRTC/Sources/MembraneRTC/Events/Event.swift
+++ b/MembraneRTC/Sources/MembraneRTC/Events/Event.swift
@@ -77,13 +77,8 @@ public enum Events {
      - to recognize the nested event's type
      - to finally deserialize the payload into an explicit event
      */
-    public static func deserialize(payload: Payload) -> ReceivableEvent? {
-        guard let rawData = payload["data"] as? String else {
-            sdkLogger.error("Failed to extract 'data' field from json payload: \(payload)")
-            return nil
-        }
-
-        let data = rawData.data(using: .utf8)!
+    public static func deserialize(payload: String) -> ReceivableEvent? {
+        let data = payload.data(using: .utf8)!
 
         guard let base: ReceivableEventBase = decodeEvent(from: data) else {
             sdkLogger.error("Failed to decode ReceivableEventBase")

--- a/MembraneRTC/Sources/MembraneRTC/MembraneRTCDelegate.swift
+++ b/MembraneRTC/Sources/MembraneRTC/MembraneRTCDelegate.swift
@@ -1,7 +1,7 @@
 /// Delegate responsible for receiving notification from `MembraneRTC` client.
 public protocol MembraneRTCDelegate {
-    /// Callback invoked when client has successfully connected via transport layer.
-    func onConnected()
+    /// Called each time MembraneWebRTC need to send some data to the server.
+    func onSendMediaEvent(event: SerializedMediaEvent)
 
     /// Callback invoked when the client has been approved to participate in session.
     func onJoinSuccess(peerID: String, peersInRoom: [Peer])
@@ -43,11 +43,6 @@ public protocol MembraneRTCDelegate {
     ///estimation - client's available incoming bitrate estimated
     ///by the server. It's measured in bits per second.
     func onBandwidthEstimationChanged(estimation: Int)
-
-    /// Callback invoked when an errors happens.
-    ///
-    /// For more information about the error type please refere to `MembraneRTCError`.
-    func onError(_ error: MembraneRTCError)
 }
 
 extension MembraneRTCDelegate {

--- a/MembraneRTC/Sources/MembraneRTC/MembraneRTCError.swift
+++ b/MembraneRTC/Sources/MembraneRTC/MembraneRTCError.swift
@@ -1,5 +1,0 @@
-public enum MembraneRTCError {
-    case rtc(String)
-    case transport(String)
-    case unknown(String)
-}

--- a/MembraneRTC/Sources/MembraneRTC/RTCEngineListener.swift
+++ b/MembraneRTC/Sources/MembraneRTC/RTCEngineListener.swift
@@ -1,4 +1,5 @@
 internal protocol RTCEngineListener {
+    func onSendMediaEvent(event: SerializedMediaEvent)
     func onPeerAccepted(peerId: String, peersInRoom: [Peer])
     func onPeerDenied()
     func onPeerJoined(peer: Peer)
@@ -14,6 +15,4 @@ internal protocol RTCEngineListener {
     func onVadNotification(trackId: String, status: String)
     func onBandwidthEstimation(estimation: Int)
     func onRemoved(peerId: String, reason: String)
-    func onError(error: EventTransportError)
-    func onClose()
 }

--- a/MembraneRTC/Sources/MembraneRTC/Types/SerializedMediaEvent.swift
+++ b/MembraneRTC/Sources/MembraneRTC/Types/SerializedMediaEvent.swift
@@ -1,0 +1,1 @@
+public typealias SerializedMediaEvent = String

--- a/MembraneVideoroomDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MembraneVideoroomDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/google/promises.git",
         "state": {
           "branch": null,
-          "revision": "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
-          "version": "2.1.1"
+          "revision": "ec957ccddbcc710ccc64c9dcbd4c7006fcf8b73a",
+          "version": "2.2.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream.git",
         "state": {
           "branch": null,
-          "revision": "e6b65c6d9077ea48b4a7bdda8994a1d3c6969c8d",
-          "version": "3.1.1"
+          "revision": "a063fda2b8145a231953c20e7a646be254365396",
+          "version": "3.1.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
-          "version": "1.0.2"
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
         }
       },
       {
@@ -51,17 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
+          "revision": "32e8d724467f8fe623624570367e3d50c5638e46",
+          "version": "1.5.2"
         }
       },
       {
@@ -69,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "e1499bc69b9040b29184f7f2996f7bab467c1639",
-          "version": "1.19.0"
+          "revision": "0af9125c4eae12a4973fb66574c53a54962a9e1e",
+          "version": "1.21.0"
         }
       },
       {

--- a/MembraneVideoroomDemo/Views/ContentView.swift
+++ b/MembraneVideoroomDemo/Views/ContentView.swift
@@ -9,7 +9,7 @@ struct ContentView: View {
 
             switch appCtrl.state {
             case .connected:
-                RoomView(appCtrl.client!)
+                RoomView(appCtrl.client!, appCtrl.displayName)
             default:
                 ConnectView()
             }

--- a/MembraneVideoroomDemo/Views/RoomView.swift
+++ b/MembraneVideoroomDemo/Views/RoomView.swift
@@ -42,9 +42,9 @@ struct RoomView: View {
     @ObservedObject var orientationReceiver: OrientationReceiver
     @State private var localDimensions: Dimensions?
 
-    init(_ room: MembraneRTC) {
+    init(_ room: MembraneRTC, _ displayName: String) {
         orientationReceiver = OrientationReceiver()
-        self.room = RoomController(room)
+        self.room = RoomController(room, displayName)
     }
 
     @ViewBuilder


### PR DESCRIPTION
- add `receiveMediaEvent` method
- add `onSendMediaEvent` callback
- user is now able to use whatever socket they want
- `connect` function no longer connects to anything so I've renamed it to `create`
- `join` function now takes peer metadata (just like web sdk and it makes more sense)