### PR TITLE
[RTC-287] Fix error related to missing arclib libraries

### DIFF
--- a/MembraneRTC.podspec
+++ b/MembraneRTC.podspec
@@ -25,8 +25,7 @@ Pod::Spec.new do |s|
   s.dependency 'SwiftProtobuf'
   s.dependency 'PromisesSwift'
   s.dependency 'SwiftPhoenixClient', '~> 4.0.0'
-  s.dependency 'Logging'
-  s.dependency 'SwiftCollection'
+  s.dependency 'SwiftLogJellyfish', '1.5.2'
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 
   s.subspec "Broadcast" do |spec|

--- a/MembraneVideoroomDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MembraneVideoroomDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -38,15 +38,6 @@
         }
       },
       {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
-          "version": "1.0.4"
-        }
-      },
-      {
         "package": "SwiftDocCPlugin",
         "repositoryURL": "https://github.com/apple/swift-docc-plugin",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,6 @@ let package = Package(
             name: "SwiftPhoenixClient", url: "https://github.com/davidstump/SwiftPhoenixClient.git",
             .upToNextMajor(from: "4.0.0")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
-        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.1")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
@@ -39,7 +38,6 @@ let package = Package(
                 "WebRTC", "SwiftProtobuf", "Promises", "SwiftPhoenixClient",
                 .product(name: "FBLPromises", package: "Promises"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "Collections", package: "swift-collections"),
             ],
             path: "Sources"
         )


### PR DESCRIPTION
- I released the newest version of the logging lib pod as `SwiftLogJellyfish` (swift-logging doesn't support cocoapods, so we had an ancient version)
- I removed `SwiftCollection` as it appears to be unecessary
- make sure `pod lib lint` passes 
- make sure the demo compiles
