### PR TITLE
[RTC-279] Allow to create tracks immediately after onConnect callback

### DIFF
--- a/Sources/MembraneRTC/MembraneRTC.swift
+++ b/Sources/MembraneRTC/MembraneRTC.swift
@@ -195,9 +195,7 @@ public class MembraneRTC: MulticastDelegate<MembraneRTCDelegate>, ObservableObje
 
             localEndpoint = localEndpoint.withTrack(trackId: videoTrack.rtcTrack().trackId, metadata: metadata)
 
-            if state == .connected {
-                engineCommunication.renegotiateTracks()
-            }
+            engineCommunication.renegotiateTracks()
 
             return videoTrack
         }
@@ -227,9 +225,7 @@ public class MembraneRTC: MulticastDelegate<MembraneRTCDelegate>, ObservableObje
 
             localEndpoint = localEndpoint.withTrack(trackId: audioTrack.rtcTrack().trackId, metadata: metadata)
 
-            if state == .connected {
-                engineCommunication.renegotiateTracks()
-            }
+            engineCommunication.renegotiateTracks()
 
             return audioTrack
         }
@@ -491,7 +487,6 @@ public class MembraneRTC: MulticastDelegate<MembraneRTCDelegate>, ObservableObje
         notify {
             $0.onConnected(endpointId: endpointId, otherEndpoints: otherEndpoints)
         }
-        engineCommunication.renegotiateTracks()
     }
 
     func onConnectionError() {

--- a/Sources/MembraneRTC/MembraneRTC.swift
+++ b/Sources/MembraneRTC/MembraneRTC.swift
@@ -91,7 +91,7 @@ public class MembraneRTC: MulticastDelegate<MembraneRTCDelegate>, ObservableObje
     }
 
     /**
-     Initializes MembraneRTC client and  sets up local audio and video track.
+     Initializes MembraneRTC client.
 
      Should not be confused with joining the actual room, which is a separate process.
 


### PR DESCRIPTION
For consistency with the web version. Merge #40 first